### PR TITLE
fix warning in md5.c

### DIFF
--- a/md5.c
+++ b/md5.c
@@ -143,8 +143,9 @@ void MD5Final(digest, ctx)
     byteReverse(ctx->in, 14);
 
     /* Append length in bits and transform */
-    ((uint32 *) ctx->in)[14] = ctx->bits[0];
-    ((uint32 *) ctx->in)[15] = ctx->bits[1];
+    // ((uint32 *) ctx->in)[14] = ctx->bits[0];
+    // ((uint32 *) ctx->in)[15] = ctx->bits[1];
+    memcpy(ctx->in + 56, ctx->bits, 8);
 
     MD5Transform(ctx->buf, (uint32 *) ctx->in);
     byteReverse((unsigned char *) ctx->buf, 4);


### PR DESCRIPTION
fix warning:

cc -Wall -O2 -DNDEBUG -I libuv/include -std=gnu99 -o \
        server server.c utils.c encrypt.c md5.c rc4.c \
        libuv/libuv.a -lpthread -lcrypto -lm -lrt
md5.c: In function ‘MD5Final’:
md5.c:146:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
md5.c:147:5: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
