### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ There is a possibility that the process will sometimes consume 100% of CPU and c
 ## Performance
 I did not fully benchmark it yet, but according to my use on [TinyVZ](http://tinyvz.com/) (OpenVZ 128M RAM and CentOS 5.8 x86). When streaming YouTube 1080p vedio at about 20Mbit/s bandwidth, it use at most 3% of RAM (RSS about 7500) and almost no CPU time. While browsing it uses less than 0.7% RAM (RSS about 1164).
 
-##Contributors
+## Contributors
 * [@messense](https://github.com/messense) Logger Color
 * [@clowwindy](https://github.com/clowwindy)
 	* Test Case and Protol Maker of shadowsocks


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
